### PR TITLE
docs: add Chinese versions for docs

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,5 +1,7 @@
 # Continuous Integration
 
+[中文版本](./CI_CN.md)
+
 This repository uses GitHub Actions to build ESP-IDF examples when they are
 added or changed.
 

--- a/docs/CI_CN.md
+++ b/docs/CI_CN.md
@@ -1,0 +1,34 @@
+# 持续集成
+
+[English Version](./CI.md)
+
+本仓库使用 GitHub Actions 在 ESP-IDF 示例新增或变更时构建这些示例。
+
+## ESP-IDF 示例构建
+
+`ESP-IDF examples` 工作流会在以下情况下运行：
+
+- Pull request 修改了 `examples/esp-idf/` 下的文件。
+- Pull request 修改了 `config/` 下共享的 ESP32-P4 芯片版本默认配置。
+- 推送到 `main` 且触及相同路径。
+- 从 GitHub Actions 页面手动运行。
+
+该工作流会查找 `examples/esp-idf/` 下同时包含以下内容的目录，以发现可构建示例：
+
+- `CMakeLists.txt`
+- `main/`
+
+对于 pull request 和 push，只会构建发生变化的示例。如果共享配置文件或工作流本身发生变化，则会构建所有 ESP-IDF 示例。
+
+手动运行时接受一个输入：
+
+| 输入 | 值 |
+| --- | --- |
+| `example` | `all`、目录名（例如 `00_board_check`），或完整路径（例如 `examples/esp-idf/19_system_monitor`） |
+
+当前工作流使用以下构建环境：
+
+- ESP-IDF Docker image：`espressif/idf:v5.5.4`
+- Target：`esp32p4`
+
+Arduino 示例目前有意暂不由该工作流构建。

--- a/docs/ESP32P4_REVISION_CONFIG.md
+++ b/docs/ESP32P4_REVISION_CONFIG.md
@@ -1,5 +1,7 @@
 # ESP32-P4 Revision Configuration
 
+[中文版本](./ESP32P4_REVISION_CONFIG_CN.md)
+
 ESP32-P4 chips earlier than rev v3.0 and chips at rev v3.0 or later are not
 binary compatible in ESP-IDF. A firmware image must be built for one side of
 that boundary.

--- a/docs/ESP32P4_REVISION_CONFIG_CN.md
+++ b/docs/ESP32P4_REVISION_CONFIG_CN.md
@@ -1,0 +1,53 @@
+# ESP32-P4 版本配置
+
+[English Version](./ESP32P4_REVISION_CONFIG.md)
+
+在 ESP-IDF 中，早于 rev v3.0 的 ESP32-P4 芯片与 rev v3.0 及之后的芯片并不二进制兼容。固件镜像必须针对这个边界的其中一侧进行构建。
+
+本仓库中的示例不会在基础 `sdkconfig.defaults` 文件中硬编码早期工程样片版本。当你需要把构建固定到某个具体芯片版本系列时，请使用下面的仓库 overlay。
+
+## 应该使用哪个配置？
+
+| 开发板上的芯片 | 推荐 overlay | 说明 |
+| --- | --- | --- |
+| ESP32-P4 rev v3.1 或更新版本 | `../../../config/esp32p4_rev_v3_1.defaults` | 匹配 ESP-IDF v5.5 默认的最小芯片版本。 |
+| ESP32-P4 rev v3.0 或更新版本 | `../../../config/esp32p4_rev_v3_0.defaults` | 当量产硬件包含 v3.0 芯片时使用。 |
+| ESP32-P4 rev v0.x 或 v1.x 工程样片 | `../../../config/esp32p4_rev_pre_v3.defaults` | 仅支持 pre-v3 芯片，不支持 v3.x 芯片。 |
+
+如果没有传入版本 overlay，ESP-IDF 会选择自己的默认值。在 ESP-IDF v5.5 中，普通构建的默认值是 rev v3.1 或更新版本。
+
+## 构建命令
+
+请在选定的 ESP-IDF 示例目录中运行命令。
+
+为 rev v3.1 或更新的量产芯片构建：
+
+```bash
+idf.py -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;../../../config/esp32p4_rev_v3_1.defaults" set-target esp32p4 build
+```
+
+为 rev v3.0 或更新的量产芯片构建：
+
+```bash
+idf.py -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;../../../config/esp32p4_rev_v3_0.defaults" set-target esp32p4 build
+```
+
+为更早的工程样片构建：
+
+```bash
+idf.py -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;../../../config/esp32p4_rev_pre_v3.defaults" set-target esp32p4 build
+```
+
+当列出基础 `sdkconfig.defaults` 文件时，ESP-IDF 会自动追加目标相关的默认配置，例如 `sdkconfig.defaults.esp32p4`。这可以让 `17_simple_video_server` 等示例继续使用相同形态的命令。
+
+当把已有示例目录从一个芯片版本系列切换到另一个版本系列时，请先删除本地生成的 `sdkconfig`，或为每个配置使用单独的 `SDKCONFIG` 文件。已有的 `sdkconfig` 选项优先级高于 defaults，否则可能隐藏你原本想测试的 overlay。
+
+## 为什么这很重要
+
+`CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` 会选择早于 v3.0 的 ESP32-P4 版本，并排除 v3.x 芯片。在 ESP-IDF 中，这个选择会影响低层 SoC 支持，例如 eFuse 布局、PMU 和电源设置、睡眠支持、PSRAM、flash 时序，以及其他依赖硬件的代码路径。
+
+对于量产，请选择与你计划出货的最老芯片匹配的最小版本。对于开发板或样片，请先通过 `examples/esp-idf/00_board_check` 的串口日志或 ESP-IDF 启动输出确认实际芯片版本。
+
+## 维护示例默认配置
+
+除非某个示例确实只适用于一个芯片版本系列，否则不要把 `CONFIG_ESP32P4_SELECTS_REV_LESS_V3` 或 `CONFIG_ESP32P4_REV_MIN_*` 直接添加到示例 `sdkconfig.defaults` 文件中。优先使用 `config/` 中共享的 overlay，这样初学者和高级用户都可以在不编辑每个示例的情况下切换硬件版本。

--- a/docs/EXAMPLES_GUIDE.md
+++ b/docs/EXAMPLES_GUIDE.md
@@ -1,5 +1,7 @@
 # Examples Guide
 
+[中文版本](./EXAMPLES_GUIDE_CN.md)
+
 The repository serves two kinds of users:
 
 - Beginners who need a clear first success.

--- a/docs/EXAMPLES_GUIDE_CN.md
+++ b/docs/EXAMPLES_GUIDE_CN.md
@@ -1,0 +1,75 @@
+# 示例指南
+
+[English Version](./EXAMPLES_GUIDE.md)
+
+本仓库服务两类用户：
+
+- 需要清晰完成第一次成功运行的初学者。
+- 希望复制聚焦外设示例到实际项目中的高级用户。
+
+使用本指南选择合适的示例。
+
+烧录前，请确认 ESP32-P4 芯片版本系列与构建配置匹配。在 ESP-IDF 中，量产 v3.x 芯片和更早的 pre-v3 工程样片是互斥的构建目标。共享的 `config/` overlay 和可复制命令请参见 [ESP32-P4 版本配置](ESP32P4_REVISION_CONFIG_CN.md)。
+
+## 学习路径
+
+| 等级 | 目标 | 示例 |
+| --- | --- | --- |
+| 0 | 验证开发板、烧录、PSRAM、heap 和 monitor | `examples/esp-idf/00_board_check` |
+| 1 | 学习标准 ESP-IDF 应用循环 | `examples/esp-idf/02_HelloWorld` |
+| 2 | 学习持久化设置和任务 | `03_nvs_counter`, `04_freertos_tasks` |
+| 3 | 尝试简单开发板 I/O | `05_gpio_io`, `06_gpio_interrupt`, `07_uart_loopback`, `08_i2c_tools` |
+| 4 | bring up 一个开发板外设 | Wi-Fi、Ethernet、SD card、display 或 audio 示例 |
+| 5 | 组合 display、camera、network 和 UI | Video 和 ESP-Brookesia 示例 |
+| Arduino | 从显示输出开始 | `examples/arduino/examples/HelloWorld` |
+
+## ESP-IDF 示例
+
+| 示例 | 难度 | 外部硬件 | 适合用途 |
+| --- | --- | --- | --- |
+| `00_board_check` | 初学者 | 无 | 第一次启动、烧录、串口监视器、PSRAM 检查 |
+| `01_HowToCreateProject` | 初学者 | 无 | 理解最小工程结构 |
+| `02_HelloWorld` | 初学者 | 无 | 经典 ESP-IDF 冒烟测试 |
+| `03_nvs_counter` | 初学者 | 无 | 保存小型持久化数值 |
+| `04_freertos_tasks` | 初学者到中级用户 | 无 | 任务、队列和周期性工作 |
+| `05_gpio_io` | 初学者 | 可选跳线或 LED | GPIO 输入/输出基础 |
+| `06_gpio_interrupt` | 初学者到中级用户 | 推荐按钮或跳线 | 中断和消抖 |
+| `07_uart_loopback` | 初学者到中级用户 | 推荐跳线 | UART 发送/接收工作流 |
+| `08_i2c_tools` | 初学者到中级用户 | 可选 I2C 设备 | 扫描和调试 I2C 总线 |
+| `09_sdmmc` | 中级用户 | SD card | 挂载和测试 SD card |
+| `10_wifistation` | 中级用户 | 支持 Wi-Fi 的开发板或 Wi-Fi 支持路径 | 连接到接入点 |
+| `11_ethernetbasic` | 中级用户 | Ethernet PHY/module | Ethernet link 和 DHCP bring-up |
+| `12_I2SCodec` | 中级用户 | Audio codec | 音乐播放或 echo mode |
+| `13_Displaycolorbar` | 中级用户 | 支持的 LCD | Display panel bring-up |
+| `14_lvgl_demo_v9` | 高级用户 | 支持的 LCD，通常需要 PSRAM | LVGL v9 UI demo |
+| `15_eth2ap` | 高级用户 | Ethernet 和 Wi-Fi 路径 | 网络桥接工作流 |
+| `16_video_lcd_display` | 高级用户 | Camera 和 LCD | Camera 到 display pipeline |
+| `17_simple_video_server` | 高级用户 | Camera 和 network | 基于浏览器的 camera streaming |
+| `18_esp_brookesia_phone` | 高级用户 | LCD/touch 和受支持开发板 profile | ESP-Brookesia UI 应用 |
+| `19_system_monitor` | 高级用户 | 无 | 串口诊断、运行时采样和持久化 monitor 设置 |
+
+## Arduino 示例
+
+| 示例 | 难度 | 外部硬件 | 说明 |
+| --- | --- | --- | --- |
+| `HelloWorld` | 初学者 | 支持的 DSI display | 第一个 Arduino display 测试 |
+| `AsciiTable` | 初学者 | 支持的 DSI display | 文本渲染网格 |
+| `Drawing_board` | 中级用户 | DSI display 和 touch | 触摸绘图 demo |
+| `GFX_ESPWiFiAnalyzer` | 中级用户 | DSI display 和 Wi-Fi | Wi-Fi 扫描可视化 |
+| `LVGLV9_Arduino` | 高级用户 | DSI display、touch、PSRAM | Arduino 上的 LVGL v9 demo |
+
+## 值得补齐的空白
+
+当前示例已经覆盖许多主要外设，但更多小示例会让仓库更友好。适合新增的方向包括：
+
+- UART 外部模块通信。
+- ADC：单次读取和周期性采样。
+- SPI：简单传感器或与显示无关的总线扫描模式。
+- Wi-Fi SoftAP：最小接入点示例。
+- HTTP client：调用公共 API 或本地服务器。
+- 文件系统基础：无需 SD card 硬件的 SPIFFS 或 LittleFS。
+- 电源管理：light sleep 和唤醒源。
+- 从完整 LVGL demo 中拆出显示基础：backlight、color fill、rotation。
+- 从 drawing board 中拆出触摸基础：原始触摸坐标日志。
+
+添加新示例时，请让它聚焦一个概念，并包含 README，说明硬件要求、构建命令、预期输出和已知限制。

--- a/docs/EXAMPLE_ROADMAP.md
+++ b/docs/EXAMPLE_ROADMAP.md
@@ -1,5 +1,7 @@
 # Example Roadmap
 
+[中文版本](./EXAMPLE_ROADMAP_CN.md)
+
 This roadmap tracks example coverage that would make the repository more
 complete for both beginners and advanced users.
 

--- a/docs/EXAMPLE_ROADMAP_CN.md
+++ b/docs/EXAMPLE_ROADMAP_CN.md
@@ -1,0 +1,57 @@
+# 示例路线图
+
+[English Version](./EXAMPLE_ROADMAP.md)
+
+这份路线图用于跟踪示例覆盖情况，目标是让本仓库同时更好地服务初学者和高级用户。
+
+## 当前优势
+
+- ESP-IDF 工程基础。
+- I2C 命令行工具。
+- NVS 持久化设置。
+- FreeRTOS 任务和队列基础。
+- UART 回环。
+- GPIO 输入/输出基础。
+- GPIO 中断和消抖。
+- Wi-Fi station 和 Ethernet 示例。
+- SDMMC 卡示例。
+- I2S codec 示例。
+- Display、LVGL、camera、video server 和 ESP-Brookesia 示例。
+- 带有内置库、偏向显示应用的 Arduino 示例。
+
+## 高优先级新增项
+
+| 优先级 | 示例 | 受众 | 重要性 |
+| --- | --- | --- | --- |
+| 高 | Display backlight and color fill | 初学者 | 比完整 LVGL 更适合显示 bring-up |
+| 高 | Touch coordinate logger | 初学者到中级用户 | 将触摸 bring-up 与绘图/UI 代码分离 |
+| 高 | UART external module template | 中级用户 | 在 loopback 基础上扩展到真实设备集成 |
+
+## 中优先级新增项
+
+| 优先级 | 示例 | 受众 | 重要性 |
+| --- | --- | --- | --- |
+| 中 | ADC periodic sampling | 初学者 | 教授模拟输入和定时器 |
+| 中 | SPI device template | 中级用户 | 帮助用户添加传感器和模块 |
+| 中 | Wi-Fi SoftAP | 中级用户 | 在没有路由器时很有用 |
+| 中 | HTTP client | 中级用户 | 常见 IoT 工作流 |
+| 中 | SPIFFS or LittleFS basics | 中级用户 | 无需 SD 硬件的文件系统工作流 |
+| 中 | Power management | 高级用户 | 产品中的睡眠和唤醒模式 |
+
+## 文档工作
+
+- 为引脚映射和支持的扩展模块添加开发板专属说明。
+- 为简单示例添加预期串口输出片段。
+- 为 display、touch、camera 和 network 示例添加故障排查章节。
+
+## 新示例质量标准
+
+每个新示例都应包含：
+
+- 聚焦明确的目标。
+- 所需硬件。
+- 支持的开发板或已知开发板假设。
+- 构建和烧录命令。
+- `menuconfig` 选项（如有）。
+- 预期串口输出或可见行为。
+- 已知限制。

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+[中文版本](./GETTING_STARTED_CN.md)
+
 This guide is written for first-time users. If you already know ESP-IDF or
 Arduino, use [EXAMPLES_GUIDE.md](EXAMPLES_GUIDE.md) to jump directly to an
 example.

--- a/docs/GETTING_STARTED_CN.md
+++ b/docs/GETTING_STARTED_CN.md
@@ -1,0 +1,65 @@
+# 入门指南
+
+[English Version](./GETTING_STARTED.md)
+
+本指南面向首次使用的用户。如果你已经熟悉 ESP-IDF 或 Arduino，可以使用 [示例指南](EXAMPLES_GUIDE_CN.md) 直接跳到合适示例。
+
+## 选择路径
+
+| 你想要... | 从这里开始 |
+| --- | --- |
+| 确认开发板和工具链可以工作 | `examples/esp-idf/00_board_check` |
+| 学习基础 ESP-IDF build 和 monitor 流程 | `examples/esp-idf/02_HelloWorld` |
+| 从 Arduino 使用显示屏 | `examples/arduino/examples/HelloWorld` |
+| bring up 一个硬件外设 | 从 [示例指南](EXAMPLES_GUIDE_CN.md) 选择 |
+| 调试 build、flash 或 boot 问题 | [故障排查](TROUBLESHOOTING_CN.md) |
+
+## 第一次运行 ESP-IDF
+
+1. 安装 ESP-IDF。除非某个示例 README 另有说明，这些示例主要面向 ESP-IDF release/v5.4 或更新版本。
+2. 打开 ESP-IDF terminal。
+3. 克隆本仓库。
+4. 构建 board check 示例：
+
+```bash
+cd examples/esp-idf/00_board_check
+idf.py set-target esp32p4
+idf.py build
+```
+
+5. 如果你的开发板使用早于 rev v3.0 的早期 ESP32-P4 工程样片，请使用 [ESP32-P4 版本配置](ESP32P4_REVISION_CONFIG_CN.md) 中记录的 pre-v3 overlay 构建。量产 v3.x 开发板可以使用常规构建流程；当你需要锁定量产 profile 时，也可以显式选择 v3.0/v3.1 overlay。
+6. 烧录并打开 monitor：
+
+```bash
+idf.py -p PORT flash monitor
+```
+
+将 `PORT` 替换为你的串口。
+
+如果看到 board check banner 和周期性的 `alive` 日志，说明你的环境已经准备好。
+
+## 第一次运行 Arduino
+
+1. 安装 Arduino IDE 或 arduino-cli。
+2. 安装兼容的 Arduino-ESP32 core。参见 [examples/arduino/README.md](../examples/arduino/README.md)。
+3. 在 Arduino board settings 中启用 PSRAM。
+4. 打开 `examples/arduino/examples/HelloWorld/HelloWorld.ino`。
+5. 选择匹配的开发板和 upload port。
+6. 上传 sketch。
+
+本仓库中的大多数 Arduino 示例都偏向显示应用。它们需要兼容的 DSI display 配置和 PSRAM。
+
+## 初学者检查清单
+
+- 使用支持数据传输的 USB 线，而不是仅充电线。
+- 确认开发板连接后串口会出现。
+- 在运行需要 Wi-Fi、Ethernet、SD card、display、touch、audio 或 camera 硬件的示例之前，先从 `00_board_check` 开始。
+- 确认你的 ESP32-P4 芯片是量产 v3.x 芯片，还是更早的工程样片。构建 profile 必须匹配该版本系列。
+- 阅读所选示例目录中的 README。
+- 如果示例有 `menuconfig` 设置，请在构建前完成配置。
+
+## 接下来阅读什么
+
+- [示例指南](EXAMPLES_GUIDE_CN.md)：按难度和外设选择示例。
+- [故障排查](TROUBLESHOOTING_CN.md)：常见设置和运行时问题。
+- [项目结构](PROJECT_STRUCTURE_CN.md)：面向贡献者的仓库布局。

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,5 +1,7 @@
 # Project Structure
 
+[中文版本](./PROJECT_STRUCTURE_CN.md)
+
 This repository is organized as a collection of examples rather than as one
 monolithic firmware application.
 

--- a/docs/PROJECT_STRUCTURE_CN.md
+++ b/docs/PROJECT_STRUCTURE_CN.md
@@ -1,0 +1,61 @@
+# 项目结构
+
+[English Version](./PROJECT_STRUCTURE.md)
+
+本仓库组织为一组示例，而不是一个单体固件应用。
+
+## 顶层目录
+
+| 路径 | 用途 |
+| --- | --- |
+| `README.md` | 项目概览、快速开始、开发板支持和兼容性矩阵 |
+| `config/` | 共享 ESP-IDF 配置 overlay，包括 ESP32-P4 芯片版本 profile |
+| `examples/` | ESP-IDF 和 Arduino 示例 |
+| `docs/` | 仓库级文档 |
+| `.github/` | issue 和 pull request 模板 |
+| `CONTRIBUTING.md` | 贡献工作流 |
+| `SUPPORT.md` | 支持渠道 |
+| `SECURITY.md` | 漏洞报告策略 |
+| `THIRD_PARTY.md` | 第三方代码清单 |
+| `LICENSE.txt` | Apache-2.0 license |
+
+## ESP-IDF 示例
+
+`examples/esp-idf/` 下的每个目录都应可以独立构建。常见文件包括：
+
+| 文件或目录 | 用途 |
+| --- | --- |
+| `CMakeLists.txt` | ESP-IDF 工程入口 |
+| `main/` | 应用源代码 |
+| `main/idf_component.yml` | 托管组件依赖（需要时） |
+| `components/` | 示例本地组件 |
+| `sdkconfig.defaults` | 提交到仓库的默认配置 |
+| `sdkconfig.ci*` | 可选的 CI 配置 overlay |
+| `partitions.csv` | 示例专属 partition table |
+| `README.md` | 示例专属设置、构建和硬件说明 |
+
+生成目录（例如 `build/`、`managed_components/`、`dependencies.lock`）以及本地 `sdkconfig` 文件不应提交。跨示例生效的芯片版本选择应使用 `config/` 中共享的 overlay，而不是复制到每个 `sdkconfig.defaults` 文件中。
+
+## Arduino 示例
+
+Arduino sketch 位于 `examples/arduino/examples/` 下。内置库位于 `examples/arduino/libraries/`，这样 sketch 可以用更少的手动依赖步骤打开和测试。
+
+添加 Arduino 内容时：
+
+- 将 sketch 添加到 `examples/arduino/examples/<ExampleName>/`。
+- 更新 `examples/README.md`。
+- 当所需 Arduino core 或内置库版本变化时，更新 `examples/arduino/README.md`。
+- 在 sketch README 或注释中记录开发板引脚假设。
+
+## 文档期望
+
+每个面向硬件的新示例都应记录：
+
+- 支持的开发板。
+- 所需外设、模块、线缆和跳线。
+- ESP-IDF 或 Arduino-ESP32 版本期望。
+- 必需的 `menuconfig` 选项或 Arduino board settings。
+- 构建、烧录和 monitor 命令。
+- 已知限制和故障排查说明。
+
+示例覆盖范围和建议新增项请参见 [示例路线图](EXAMPLE_ROADMAP_CN.md)。

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,5 +1,7 @@
 # Troubleshooting
 
+[中文版本](./TROUBLESHOOTING_CN.md)
+
 Start with `examples/esp-idf/00_board_check`. It has no external hardware
 requirements and helps separate toolchain problems from peripheral problems.
 

--- a/docs/TROUBLESHOOTING_CN.md
+++ b/docs/TROUBLESHOOTING_CN.md
@@ -1,0 +1,118 @@
+# 故障排查
+
+[English Version](./TROUBLESHOOTING.md)
+
+从 `examples/esp-idf/00_board_check` 开始。它不需要外部硬件，可以帮助区分工具链问题和外设问题。
+
+## 构建问题
+
+### 找不到 `idf.py`
+
+构建前先打开 ESP-IDF terminal，或 source ESP-IDF export script。然后运行：
+
+```bash
+idf.py --version
+```
+
+### 目标芯片错误
+
+本仓库中的大多数示例目标芯片是 ESP32-P4。请在示例目录中运行：
+
+```bash
+idf.py set-target esp32p4
+```
+
+### ESP32-P4 芯片版本不匹配
+
+早于 rev v3.0 的 ESP32-P4 芯片与 rev v3.0 或之后的芯片是互斥构建目标。如果镜像可以构建但无法在另一个 P4 版本系列上启动，请使用 [ESP32-P4 版本配置](ESP32P4_REVISION_CONFIG_CN.md) 中正确的 overlay 重新构建。
+
+对于早期工程样片：
+
+```bash
+idf.py -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;../../../config/esp32p4_rev_pre_v3.defaults" set-target esp32p4 build
+```
+
+对于量产芯片，优先使用文档中的 v3.0 或 v3.1 overlay，也可以让 ESP-IDF 使用默认量产版本 profile。
+
+### 托管组件下载失败
+
+一些示例会通过 `idf_component.yml` 获取依赖。请检查网络连接并重试构建。如果你位于代理后面，请先配置 ESP-IDF 和 Git proxy settings。
+
+### VS Code plugin 构建失败
+
+一些网络示例包含旧说明：通过 VS Code plugin 工作流构建时可能失败。请先使用 ESP-IDF terminal：
+
+```bash
+cd examples/esp-idf/10_wifistation
+idf.py set-target esp32p4
+idf.py menuconfig
+idf.py build
+```
+
+终端构建成功后，再对比 VS Code plugin 的环境、target 和配置。
+
+## 烧录和监视器问题
+
+### 串口缺失
+
+- 使用支持数据传输的 USB 线。
+- 在 Windows 上检查 Device Manager，或在 Linux/macOS 上检查 `/dev/tty*`。
+- 关闭其他串口监视程序。
+- 如果你的开发板需要手动 boot mode，请按下 reset 或 boot 按键。
+
+### 烧录成功但 monitor 输出不可读
+
+检查 monitor baud rate。使用以下命令时，ESP-IDF 默认值通常是正确的：
+
+```bash
+idf.py -p PORT flash monitor
+```
+
+## 运行时问题
+
+### PSRAM 未初始化
+
+许多 display、LVGL、camera 和 Arduino 示例需要 PSRAM。请用 `00_board_check` 确认 PSRAM，然后检查示例的 `sdkconfig.defaults` 和开发板设置。
+
+### Wi-Fi 无法连接
+
+- 确认开发板具备 Wi-Fi 支持，或已配置 Wi-Fi companion 路径。
+- 运行 `idf.py menuconfig` 并设置 SSID/password。
+- 检查接入点是否为 2.4 GHz 且可达。
+- 查看串口日志中的认证、超时或重试消息。
+
+### Ethernet link down
+
+- 确认开发板具备 Ethernet 硬件。
+- 检查 PHY model、PHY address、MDC/MDIO GPIO、reset GPIO 和 clock mode。
+- 确认网线、交换机和 DHCP server。
+
+### SD card 挂载失败
+
+- 确认 card 已插入并已格式化。
+- 如果接线或信号完整性不确定，尝试 1-line SDMMC mode。
+- 除非你愿意擦除 card，否则不要启用格式化选项。
+
+### 显示屏空白
+
+- 确认已选择正确的 panel 和 `CURRENT_SCREEN` 或 BSP 配置。
+- 确认已启用 PSRAM。
+- 先检查 backlight control，再查看 panel init 日志。
+- 在运行 LVGL demo 之前，先从简单 color bar 或 Arduino `HelloWorld` 开始。
+
+### 触摸无响应
+
+- 确认 touch controller model 和 I2C pins。
+- 使用 I2C scan 检查 touch controller 是否出现在总线上。
+- 当 touch driver 需要 reset 和 interrupt pins 时，确认这些引脚。
+
+## 寻求帮助
+
+提交 issue 时，请包含：
+
+- 开发板名称和版本。
+- 示例路径。
+- ESP-IDF 或 Arduino-ESP32 版本。
+- 完整构建命令。
+- 完整错误日志或串口输出。
+- 涉及外部硬件时，提供照片或接线说明。


### PR DESCRIPTION
## Summary
- Add Chinese `_CN.md` versions for all Markdown files under `docs/`.
- Add bidirectional English/Chinese language links to each docs page.
- Point Chinese internal docs links to the Chinese versions where applicable.

## Checks
- `git diff --check -- docs`
- Docs link check: 7 English docs and 7 Chinese docs, all mutually linked.